### PR TITLE
Fix HeaderMap type mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ url = { version = "2.4.1", default-features = false }
 simplerusthttpsclient =  { version = "0.1.17", features = ["tls"], default-features = false}
 tokio = { version = "1.33.0", default-features = false, features = ["macros"] }
 reqwest = { version = "0.11.22", default-features = false, features = ["json","multipart"] }
+http = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use url::Url;
-use reqwest::header::HeaderMap;
+use http::header::HeaderMap;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary
- fix mismatched `HeaderMap` type by using `http::header::HeaderMap`
- add `http` crate dependency

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687cafba8f9c8326a1b4fe47eb4aae85